### PR TITLE
update DNS OPTIONS cloudflare url dans proxy.py

### DIFF
--- a/src/autoflix_cli/proxy.py
+++ b/src/autoflix_cli/proxy.py
@@ -22,7 +22,7 @@ app = Flask(__name__)
 
 # Requested Cloudflare DNS Options
 DNS_OPTIONS = {
-    CurlOpt.DOH_URL: "https://1.1.1.1/dns-query",
+    CurlOpt.DOH_URL: "https://cloudflare-dns.com/dns-query",
     CurlOpt.DOH_SSL_VERIFYPEER: 0,
     CurlOpt.DOH_SSL_VERIFYHOST: 0,
 }


### PR DESCRIPTION
Voila voila
je sais pas trop pourquoi ça ne fonctionnait plus avec l'ancienne url du dns de cloudflare mais maintenant c'est réglé